### PR TITLE
FIX BUG: only the last variable is replaced

### DIFF
--- a/src/handyllm/prompt_converter.py
+++ b/src/handyllm/prompt_converter.py
@@ -62,11 +62,10 @@ class PromptConverter:
         else:
             new_chat = []
             for message in chat:
+                new_message = {"role": message['role'], "content": message['content']}
                 for var, value in variable_map.items():
                     if var in message['content']:
-                        new_message = {"role": message['role'], "content": message['content'].replace(var, value)}
-                    else:
-                        new_message = {"role": message['role'], "content": message['content']}
+                        new_message = {"role": new_message['role'], "content": new_message['content'].replace(var, value)}
                 new_chat.append(new_message)
             return new_chat
 


### PR DESCRIPTION
修复了这个bug：prompt文件里如果有多个 %变量% 需要替换，只有最后一个变量被成功替换。


因为此前的代码里，每一次用variable_map里的词条替换时，都用的老message['content']来为new_message赋值。
----------------------Old Version----------------------------
            for message in chat:
                for var, value in variable_map.items():
                    if var in message['content']:
                        new_message = {"role": message['role'], "content": message['content'].replace(var, value)}